### PR TITLE
Add an option to check URLs only from specific sections

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,8 @@ jobs:
           existing-check-enabled: true
           existing-check-labels: |
             ["enhancement", "question"]
-          url-search-sections: ["URL section"]
+          url-search-sections: |
+            ["URL section"]
           auto-close-rules: |
             [
               {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
           existing-check-enabled: true
           existing-check-labels: |
             ["enhancement", "question"]
+          url-search-sections: ["URL section"]
           auto-close-rules: |
             [
               {

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ If `member-token` is not provided, `repo-token` will be used to check user's mem
 | `existing-check-labels`   | Labels of the opened issues to do the check.                                                    |
 | `existing-check-repo-url` | URL of the JSON extension repository.                                                           |
 | `existing-check-comment`  | Comment body when the issue was detected to be of an existing source.                           |
+| `url-search-sections`     | Sections of the issue to check for URLs. Applies to both existing and duplicate checks.         |
 | `auto-close-rules`        | A JSON-compliant string containing a list of rules, where a rule consists of the content below. |
 | `auto-close-ignore-label` | Optional label name. If present, auto-close, duplicate-check, and existing-check are skipped.   |
 
@@ -83,6 +84,8 @@ to be added to your repository through issues.
 
 To enable it, you need to set `duplicate-check-enabled` to `true`
 and define the label that the action should check with `duplicate-check-label`.
+
+If you wish to check only specific sections of the issue, define the names of those sections with `url-search-sections`.
 
 ### Regex rules
 

--- a/action.yml
+++ b/action.yml
@@ -91,6 +91,14 @@ inputs:
 
       *This is an automated action. If you think this is a mistake, please comment about it so the issue can be reopened if needed.*
 
+  url-search-sections:
+    required: false
+    description: >
+      A JSON-compliant string containing a list of issue sections to check for URLs. Applies to duplicate and existing checks.
+      If defined, only the specified sections are checked.
+      If not defined or if an empty list is provided, the whole issue body is checked.
+    default: []
+
   auto-close-rules:
     required: false
     description: |

--- a/action.yml
+++ b/action.yml
@@ -97,7 +97,8 @@ inputs:
       A JSON-compliant string containing a list of issue sections to check for URLs. Applies to duplicate and existing checks.
       If defined, only the specified sections are checked.
       If not defined or if an empty list is provided, the whole issue body is checked.
-    default: []
+    default: |
+      []
 
   auto-close-rules:
     required: false

--- a/src/feature/duplicate-url-check.ts
+++ b/src/feature/duplicate-url-check.ts
@@ -39,7 +39,8 @@ export async function checkForDuplicateUrls() {
     return;
   }
 
-  const issueUrls = urlsFromIssueBody(issue.body);
+  const sectionsToCeck = JSON.parse(core.getInput('url-search-sections'))
+  const issueUrls = urlsFromIssueBody(issue.body, sectionsToCeck);
   if (issueUrls.length === 0) {
     core.info('No URLs found in the issue body');
     return;
@@ -74,7 +75,7 @@ export async function checkForDuplicateUrls() {
       let urls: string[];
       return (
         currIssue.number !== issue.number &&
-        (urls = urlsFromIssueBody(currIssue.body ?? '')) &&
+        (urls = urlsFromIssueBody(currIssue.body ?? '', sectionsToCeck)) &&
         issueUrls.some((url) => urls.includes(url))
       );
     })

--- a/src/feature/existing-source-check.ts
+++ b/src/feature/existing-source-check.ts
@@ -50,7 +50,8 @@ export async function checkForExistingSource() {
     return;
   }
 
-  const issueUrls = urlsFromIssueBody(issue.body);
+  const sectionsToCeck = JSON.parse(core.getInput('url-search-sections'))
+  const issueUrls = urlsFromIssueBody(issue.body, sectionsToCeck);
   if (issueUrls.length === 0) {
     core.info('No URLs found in the issue body');
     return;

--- a/src/util/urls.test.ts
+++ b/src/util/urls.test.ts
@@ -60,6 +60,31 @@ describe('urlsFromIssueBody', () => {
       expect(urlsFromIssueBody(body, sections)).toStrictEqual(expectedUrls);
     });
   });
+
+  const sectionsExample =
+`### First
+one.tld
+### Middle
+www.two.tld
+### Empty
+just some text
+### Last
+https://three.tld
+`;
+
+  it('checks sections', () => {
+    (
+      [
+        [ sectionsExample, ['First'], ['one.tld']],
+        [ sectionsExample, ['Middle'], ['two.tld']],
+        [ sectionsExample, ['Last'], ['three.tld']],
+        [ sectionsExample, ['First', 'Last', 'Non-existent'], ['one.tld', 'three.tld']],
+        [ sectionsExample, ['Empty'], []],
+      ] as const
+    ).forEach(([body, sections, expectedUrls]) => {
+      expect(urlsFromIssueBody(body, sections)).toStrictEqual(expectedUrls);
+    });
+  });
 });
 
 describe('cleanUrl', () => {

--- a/src/util/urls.test.ts
+++ b/src/util/urls.test.ts
@@ -6,13 +6,13 @@ describe('urlsFromIssueBody', () => {
   it('extracts URLs', () => {
     (
       [
-        ['foo https://example.org bar', ['example.org']],
+        ['foo https://example.org bar', [], ['example.org']],
         [
-          'foo https://example.ORG google.co.UK bar',
+          'foo https://example.ORG google.co.UK bar', [],
           ['example.org', 'google.co.uk'],
         ],
         [
-          'foo http://stupidlylongtld.NORTHWESTERNMUTUAL',
+          'foo http://stupidlylongtld.NORTHWESTERNMUTUAL', [],
           ['stupidlylongtld.northwesternmutual'],
         ],
         [
@@ -35,29 +35,29 @@ describe('urlsFromIssueBody', () => {
     - [X] I have updated all installed extensions.
     - [X] I have checked if the source URL is not already updated by opening WebView.
     - [X] I will fill out all of the requested information in this form.`,
-          ['wings.sbs'],
+          [], ['wings.sbs'],
         ],
       ] as const
-    ).forEach(([body, expectedUrls]) => {
-      expect(urlsFromIssueBody(body)).toStrictEqual(expectedUrls);
+    ).forEach(([body, sections, expectedUrls]) => {
+      expect(urlsFromIssueBody(body, sections)).toStrictEqual(expectedUrls);
     });
   });
 
   it('excludes some URLs', () => {
     (
       [
-        ['foo https://tachiyomi.org/extensions bar', []],
-        ['foo https://github.com/tachiyomiorg bar', []],
-        ['foo user-images.githubusercontent.com/something bar', []],
-        ['foo www.gist.github.com/something bar', []],
+        ['foo https://tachiyomi.org/extensions bar', [], []],
+        ['foo https://github.com/tachiyomiorg bar', [], []],
+        ['foo user-images.githubusercontent.com/something bar', [], []],
+        ['foo www.gist.github.com/something bar', [], []],
         [
-          'foo https://github.com/tachiyomiorg/extensions/blob/master/README.md something',
+          'foo https://github.com/tachiyomiorg/extensions/blob/master/README.md something', [],
           [],
         ],
-        ['foo https://keiyoushi.github.io/extensions bar', []],
+        ['foo https://keiyoushi.github.io/extensions bar', [], []],
       ] as const
-    ).forEach(([body, expectedUrls]) => {
-      expect(urlsFromIssueBody(body)).toStrictEqual(expectedUrls);
+    ).forEach(([body, sections, expectedUrls]) => {
+      expect(urlsFromIssueBody(body, sections)).toStrictEqual(expectedUrls);
     });
   });
 });

--- a/src/util/urls.ts
+++ b/src/util/urls.ts
@@ -15,11 +15,29 @@ export function urlsFromString(str: string): string[] {
   return Array.from(str.matchAll(URL_REGEX)).map((url) => cleanUrl(url[0]));
 }
 
-export function urlsFromIssueBody(body: string): string[] {
-  const urls = urlsFromString(body)
-    .filter((url) => !EXCLUSION_LIST.includes(url))
-    .filter((url) => EXCLUDED_DOMAINS.every((domain) => !url.endsWith(domain)));
-  return Array.from(new Set(urls));
+export function urlsFromIssueBody(body: string, sections: string[]): string[] {
+  const textsToSearch = [] as string[];
+  if (sections && sections.length) {
+    // if sections are properly defined, seach only those sections
+    for (let sectionName of sections) {
+      const sectionContent = findSection(body, sectionName);
+      if (sectionContent) textsToSearch.push(sectionContent);
+    }
+  } else {
+    // if no sections are defined, seach the whole body
+    textsToSearch.push(body)
+  }
+
+  const urls = new Set<string>();
+  for (let text in textsToSearch) {
+    console.log('Searching for URLs in the following text:')
+    console.log(text)
+    urls.add(urlsFromString(text)
+      .filter((url) => !EXCLUSION_LIST.includes(url))
+      .filter((url) => EXCLUDED_DOMAINS.every((domain) => !url.endsWith(domain)))
+    );
+  }
+  return Array.from(urls);
 }
 
 export function cleanUrl(url: string): string {
@@ -27,4 +45,12 @@ export function cleanUrl(url: string): string {
     .toLowerCase()
     .replace(/(https?:\/\/)?(www\.)?/g, '')
     .replace(/\/$/, '');
+}
+
+function findSection(body: string, sectionName: string) {
+  const start = body.indexOf(`# ${sectionName}`);
+  if (start == -1) return false;
+
+  const end = body.indexOf('\n#', start + 1);
+  return body.substring(start, end);
 }

--- a/src/util/urls.ts
+++ b/src/util/urls.ts
@@ -29,13 +29,13 @@ export function urlsFromIssueBody(body: string, sections: string[]): string[] {
   }
 
   const urls = new Set<string>();
-  for (let text in textsToSearch) {
+  for (let text of textsToSearch) {
     console.log('Searching for URLs in the following text:')
     console.log(text)
-    urls.add(urlsFromString(text)
+    urlsFromString(text)
       .filter((url) => !EXCLUSION_LIST.includes(url))
       .filter((url) => EXCLUDED_DOMAINS.every((domain) => !url.endsWith(domain)))
-    );
+      .map((url) => urls.add(url));
   }
   return Array.from(urls);
 }
@@ -52,5 +52,7 @@ function findSection(body: string, sectionName: string) {
   if (start == -1) return false;
 
   const end = body.indexOf('\n#', start + 1);
+  if (end == -1) return body.substring(start);
+
   return body.substring(start, end);
 }

--- a/src/util/urls.ts
+++ b/src/util/urls.ts
@@ -30,8 +30,6 @@ export function urlsFromIssueBody(body: string, sections: string[]): string[] {
 
   const urls = new Set<string>();
   for (let text of textsToSearch) {
-    console.log('Searching for URLs in the following text:')
-    console.log(text)
     urlsFromString(text)
       .filter((url) => !EXCLUSION_LIST.includes(url))
       .filter((url) => EXCLUDED_DOMAINS.every((domain) => !url.endsWith(domain)))


### PR DESCRIPTION
This allows us to define whether we wish to check for URLs only in specific sections of the issue instead of the whole body. Helps with cases when the source name contains a domain or when a different URL is present in other sections of the issue.

For the ext source repo, this line should be added to the workflow after the action is updated:
```yml
url-search-sections: |
  ["Source link", "Source new URL"]
```

Closes #46 

However, it does NOT resolve the issue from the comment about checking only the first URL for existing sources. While this feature will reduce the impact, the "first URL only" issue should be fixed separately. I have opened a separate PR for this: #320