### PR TITLE
Update Node.js used by the action from 20 to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   icon: alert-circle
   color: red
 runs:
-  using: node20
+  using: node24
   main: dist/index.js
 inputs:
   repo-token:


### PR DESCRIPTION
GitHub shows a warning when using this action that Node.js 20 will soon be deprecated, but Renovate doesn't catch this for some reason.

Relevant docs: https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#runsusing-for-javascript-actions